### PR TITLE
Avoid 0x80000003 on 32-bit Windows in msnmntr.

### DIFF
--- a/network/trans/msnmntr/sys/msnmntr.c
+++ b/network/trans/msnmntr/sys/msnmntr.c
@@ -384,7 +384,7 @@ cleanup:
       flowContext = NULL;
    }
 
-   return (UINT64) flowContext;
+   return (UINT64)(uintptr_t) flowContext;
 }
 
 NTSTATUS MonitorCoInitialize(_Inout_ DEVICE_OBJECT* deviceObject)


### PR DESCRIPTION
The exception occurs in MonitorCoStreamFlowDeletion, but the bug is in MonitorCoCreateFlowContext.

In 32-bit Windows, the high bit of kernel mode pointers is set, and the pointer value is 0x80000000 or above.  Casting 0x80000000 to a UINT64 yields 0xffffffff80000000 because of sign extension.  ULongLongToULongPtr converts 0xffffffff80000000 to 0xffffffff.  Boom.

Cast using an intermediate uintptr_t to avoid the sign extension in the first place.